### PR TITLE
history list, detailed view and structure changes

### DIFF
--- a/frontend/lib/components/history_list.dart
+++ b/frontend/lib/components/history_list.dart
@@ -1,0 +1,70 @@
+import 'package:economicalc_client/helpers/utils.dart';
+import 'package:economicalc_client/screens/transaction_details_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class HistoryList extends StatelessWidget {
+  HistoryList({
+    Key? key,
+  }) : super(key: key);
+
+  final transactions = Utils.getMockedTransactions(); // TODO: fetch from db
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
+      Container(
+        padding: const EdgeInsets.only(left: 20),
+        child: Text(
+          "History",
+          textAlign: TextAlign.left,
+          style: TextStyle(
+              color: Colors.black, fontSize: 32, fontWeight: FontWeight.bold),
+        ),
+      ),
+      Expanded(
+          child: ListView.builder(
+              padding: EdgeInsets.all(20.0),
+              itemCount: transactions.length,
+              itemBuilder: (BuildContext ctx, int index) {
+                return Padding(
+                    padding: EdgeInsets.only(top: 5.0),
+                    child: ListTile(
+                      tileColor: Color(0xffD4E6F3),
+                      shape: ContinuousRectangleBorder(
+                          side: BorderSide(
+                        width: 1.0,
+                        color: Colors.transparent,
+                      )),
+                      title: Text(
+                        transactions[index].recipient,
+                        style: TextStyle(
+                            fontWeight: FontWeight.w600, fontSize: 18),
+                      ),
+                      subtitle: Text(
+                        transactions[index].amount.toString(),
+                        style: TextStyle(
+                            fontWeight: FontWeight.w600, fontSize: 16),
+                      ),
+                      leading: Text(
+                        DateFormat('yyyy-MM-dd')
+                            .format(transactions[index].date),
+                        style: TextStyle(
+                            fontWeight: FontWeight.w600, fontSize: 16),
+                      ),
+                      trailing: const Icon(
+                        Icons.arrow_right_alt_sharp,
+                        size: 50,
+                      ),
+                      onTap: () {
+                        Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                                builder: ((context) =>
+                                    TransactionDetailsScreen())));
+                      },
+                    ));
+              }))
+    ]);
+  }
+}

--- a/frontend/lib/helpers/utils.dart
+++ b/frontend/lib/helpers/utils.dart
@@ -1,0 +1,97 @@
+import 'package:economicalc_client/models/transaction_event.dart';
+
+class Utils {
+  static List<TransactionEvent> getMockedTransactions() {
+    return [
+      TransactionEvent(
+        userID: 1,
+        recipient: "Ica",
+        date: DateTime(2022, 10, 24),
+        amount: 204.5,
+        items: getMockedReceiptItems(),
+      ),
+      TransactionEvent(
+        userID: 1,
+        recipient: "Willys",
+        date: DateTime(2022, 10, 24),
+        amount: 55.00,
+        items: getMockedReceiptItems(),
+      ),
+      TransactionEvent(
+        userID: 1,
+        recipient: "Donken",
+        date: DateTime(2022, 10, 24),
+        amount: 75.99,
+        items: getMockedReceiptItems(),
+      ),
+      TransactionEvent(
+        userID: 1,
+        recipient: "H&M",
+        date: DateTime(2022, 10, 25),
+        amount: 300.00,
+        items: getMockedReceiptItems(),
+      ),
+      TransactionEvent(
+        userID: 1,
+        recipient: "Hemköp",
+        date: DateTime(2022, 10, 27),
+        amount: 109.99,
+        items: getMockedReceiptItems(),
+      ),
+      TransactionEvent(
+        userID: 1,
+        recipient: "Donken",
+        date: DateTime(2022, 10, 28),
+        amount: 68.99,
+        items: getMockedReceiptItems(),
+      ),
+      TransactionEvent(
+        userID: 1,
+        recipient: "Donken",
+        date: DateTime(2022, 10, 24),
+        amount: 75.99,
+        items: getMockedReceiptItems(),
+      ),
+      TransactionEvent(
+        userID: 1,
+        recipient: "H&M",
+        date: DateTime(2022, 10, 25),
+        amount: 300.00,
+        items: getMockedReceiptItems(),
+      ),
+      TransactionEvent(
+        userID: 1,
+        recipient: "Hemköp",
+        date: DateTime(2022, 10, 27),
+        amount: 109.99,
+        items: getMockedReceiptItems(),
+      ),
+      TransactionEvent(
+        userID: 1,
+        recipient: "Donken",
+        date: DateTime(2022, 10, 28),
+        amount: 68.99,
+        items: getMockedReceiptItems(),
+      ),
+    ];
+  }
+
+  static List<ReceiptItem> getMockedReceiptItems() {
+    return [
+      ReceiptItem(itemName: "Tomatoes", quantity: 19, price: 21.99, sum: 21.99),
+      ReceiptItem(itemName: "Potatoes", quantity: 32, price: 15.99, sum: 15.99),
+      ReceiptItem(itemName: "Marabou", quantity: 2, price: 20.00, sum: 40.00),
+      ReceiptItem(itemName: "Onion", quantity: 30, price: 21.00, sum: 40.00),
+      ReceiptItem(itemName: "Garlic", quantity: 20, price: 22.00, sum: 40.00),
+      ReceiptItem(itemName: "Cucumber", quantity: 15, price: 23.00, sum: 40.00),
+      ReceiptItem(itemName: "Flour", quantity: 5, price: 24.00, sum: 40.00),
+      ReceiptItem(itemName: "Yeast", quantity: 10, price: 25.00, sum: 40.00),
+      ReceiptItem(itemName: "Hat", quantity: 59, price: 26.00, sum: 40.00),
+      ReceiptItem(itemName: "Cheese", quantity: 1, price: 27.00, sum: 40.00),
+      ReceiptItem(itemName: "Milk", quantity: 3, price: 28.00, sum: 40.00),
+      ReceiptItem(itemName: "Yoghurt", quantity: 5, price: 29.00, sum: 40.00),
+      ReceiptItem(itemName: "Pasta", quantity: 3, price: 30.00, sum: 40.00),
+      ReceiptItem(itemName: "Meatballs", quantity: 2, price: 31.00, sum: 41.00),
+    ];
+  }
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:economicalc_client/home_screen.dart';
+import 'package:economicalc_client/screens/home_screen.dart';
 import 'package:flutter/material.dart';
 
 void main() {

--- a/frontend/lib/models/transaction_event.dart
+++ b/frontend/lib/models/transaction_event.dart
@@ -1,0 +1,27 @@
+class TransactionEvent {
+  int userID;
+  String recipient;
+  DateTime date;
+  num amount;
+  List<ReceiptItem> items;
+
+  TransactionEvent(
+      {required this.userID,
+      required this.recipient,
+      required this.date,
+      required this.amount,
+      required this.items});
+}
+
+class ReceiptItem {
+  String itemName;
+  int quantity;
+  num price;
+  num sum;
+
+  ReceiptItem(
+      {required this.itemName,
+      required this.quantity,
+      required this.price,
+      required this.sum});
+}

--- a/frontend/lib/screens/camera_screen.dart
+++ b/frontend/lib/screens/camera_screen.dart
@@ -1,5 +1,5 @@
 import 'package:camera/camera.dart';
-import 'package:economicalc_client/home_screen.dart';
+import 'package:economicalc_client/screens/home_screen.dart';
 import 'package:flutter/material.dart';
 
 class CameraScreen extends StatefulWidget {

--- a/frontend/lib/screens/home_screen.dart
+++ b/frontend/lib/screens/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:economicalc_client/camera_screen.dart';
+import 'package:economicalc_client/components/history_list.dart';
+import 'package:economicalc_client/screens/camera_screen.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 late BuildContext _context;
@@ -40,6 +41,7 @@ class _HomeScreen extends State<HomeScreen> {
   }
 
   Widget iconSection = Container(
+    padding: EdgeInsets.only(top: 10),
     child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: <Widget>[
@@ -127,9 +129,12 @@ class _HomeScreen extends State<HomeScreen> {
         child: Scaffold(
             key: _globalKey,
             drawer: drawer,
-            body: Wrap(
-              runSpacing: 50,
-              children: [titleSection(_globalKey), iconSection],
+            body: Column(
+              children: [
+                titleSection(_globalKey),
+                iconSection,
+                Expanded(child: HistoryList())
+              ],
             )));
   }
 }

--- a/frontend/lib/screens/transaction_details_screen.dart
+++ b/frontend/lib/screens/transaction_details_screen.dart
@@ -1,5 +1,5 @@
-import 'package:frontend/helpers/utils.dart';
-import 'package:frontend/models/transaction_event.dart';
+import 'package:economicalc_client/helpers/utils.dart';
+import 'package:economicalc_client/models/transaction_event.dart';
 import 'package:flutter/material.dart';
 
 class TransactionDetailsScreen extends StatefulWidget {

--- a/frontend/lib/screens/transaction_details_screen.dart
+++ b/frontend/lib/screens/transaction_details_screen.dart
@@ -1,0 +1,116 @@
+import 'package:frontend/helpers/utils.dart';
+import 'package:frontend/models/transaction_event.dart';
+import 'package:flutter/material.dart';
+
+class TransactionDetailsScreen extends StatefulWidget {
+  @override
+  TransactionDetailsScreenState createState() =>
+      TransactionDetailsScreenState();
+}
+
+class TransactionDetailsScreenState extends State<TransactionDetailsScreen> {
+  int? sortColumnIndex;
+  bool isAscending = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          backgroundColor: Color(0xFFB8D8D8),
+          foregroundColor: Colors.black,
+          title: const Text("EconomiCalc",
+              style: TextStyle(
+                  color: Color(0xff000000),
+                  fontWeight: FontWeight.bold,
+                  fontSize: 36.0)),
+          centerTitle: true,
+          elevation: 0,
+        ),
+        body: ListView(
+            children: [headerInfo(), Expanded(child: buildDataTable())]));
+  }
+
+  Widget headerInfo() {
+    return Container(
+        padding: EdgeInsets.all(20),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            Expanded(
+                child: Column(children: [
+              Text(
+                "Mat & Dryck",
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
+              ),
+              Text(
+                "Ica Väst",
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+              ),
+              Text("2022-10-01",
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.w400))
+            ])),
+            Text("Total: 210.99 kr",
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600)),
+            IconButton(
+                onPressed: (() {
+                  print("receipt");
+                }),
+                icon: Icon(Icons.receipt_long))
+          ],
+        ));
+  }
+
+  final columns = ["Items", "Price", "Qty", "Sum"];
+  final rows = Utils.getMockedReceiptItems();
+
+  Widget buildDataTable() {
+    return DataTable(
+        columnSpacing: 30,
+        sortAscending: isAscending,
+        sortColumnIndex: sortColumnIndex,
+        columns: getColumns(columns),
+        rows: getRows(rows));
+  }
+
+  List<DataColumn> getColumns(List<String> columns) => columns
+      .map((String column) => DataColumn(
+          label: Text(column,
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16.0)),
+          onSort: onSort))
+      .toList();
+
+  List<DataRow> getRows(List<ReceiptItem> items) =>
+      items.map((ReceiptItem item) {
+        final cells = [item.itemName, item.price, item.quantity, item.sum];
+        return DataRow(cells: getCells(cells));
+      }).toList();
+
+  List<DataCell> getCells(List<dynamic> cells) =>
+      cells.map((data) => DataCell(Text('$data'))).toList();
+
+  void onSort(int columnIndex, bool ascending) {
+    if (columnIndex == 0) {
+      rows.sort((row1, row2) =>
+          compareString(ascending, row1.itemName, row2.itemName));
+    } else if (columnIndex == 1) {
+      rows.sort(
+          (row1, row2) => compareNumber(ascending, row1.price, row2.price));
+    } else if (columnIndex == 2) {
+      rows.sort((row1, row2) =>
+          compareNumber(ascending, row1.quantity, row2.quantity));
+    } else if (columnIndex == 3) {
+      rows.sort((row1, row2) => compareNumber(ascending, row1.sum, row2.sum));
+    }
+
+    setState(() {
+      sortColumnIndex = columnIndex;
+      isAscending = ascending;
+    });
+  }
+
+  int compareString(bool ascending, String value1, String value2) =>
+      ascending ? value1.compareTo(value2) : value2.compareTo(value1);
+
+  int compareNumber(bool ascending, num value1, num value2) =>
+      ascending ? value1.compareTo(value2) : value2.compareTo(value1);
+}


### PR DESCRIPTION
Adds transaction history list with hardcoded transaction entries to home page as well as a detailed view including hardcoded individual items for each transaction entry.

Two issues should be added to backlog after merge:
1. Fix so that the history list items are not visible through the title and icons
2. Fix so that the "Incorrect use of ParentDataWidget" exception is not thrown when in the detailed view