### PR TITLE
new data structure to merge receipts and bank transactions

### DIFF
--- a/frontend/assets/test_data.json
+++ b/frontend/assets/test_data.json
@@ -1,0 +1,96 @@
+{
+  "transactions": [
+    {
+      "id": "c9ae8be0b4fd4820881f0faeae502a6f",
+      "accountId": "8c90db09536e4d35b82e99138cb5d069",
+      "amount": {
+        "value": {
+          "unscaledValue": "-2999",
+          "scale": "1"
+        },
+        "currencyCode": "SEK"
+      },
+      "descriptions": {
+        "original": "ICA",
+        "display": "Ica"
+      },
+      "dates": {
+        "booked": "2022-11-21"
+      },
+      "types": {
+        "type": "DEFAULT"
+      },
+      "status": "PENDING",
+      "providerMutability": "MUTABILITY_UNDEFINED"
+    },
+    {
+      "id": "c9f3c9af754642638902b41fbf9077b2",
+      "accountId": "8c90db09536e4d35b82e99138cb5d069",
+      "amount": {
+        "value": {
+          "unscaledValue": "-2790",
+          "scale": "1"
+        },
+        "currencyCode": "SEK"
+      },
+      "descriptions": {
+        "original": "Storstockholms Lokaltrafik",
+        "display": "Storstockholms Lokaltrafik"
+      },
+      "dates": {
+        "booked": "2022-11-21"
+      },
+      "types": {
+        "type": "DEFAULT"
+      },
+      "status": "PENDING",
+      "providerMutability": "MUTABILITY_UNDEFINED"
+    },
+    {
+      "id": "28bccac0740340f0982f99018103c4c1",
+      "accountId": "8c90db09536e4d35b82e99138cb5d069",
+      "amount": {
+        "value": {
+          "unscaledValue": "-1290",
+          "scale": "1"
+        },
+        "currencyCode": "SEK"
+      },
+      "descriptions": {
+        "original": "Arlanda Express",
+        "display": "Arlanda Express"
+      },
+      "dates": {
+        "booked": "2022-11-20"
+      },
+      "types": {
+        "type": "DEFAULT"
+      },
+      "status": "PENDING",
+      "providerMutability": "MUTABILITY_UNDEFINED"
+    },
+    {
+      "id": "7a440c60578344e2bbf359a3da9dc250",
+      "accountId": "8c90db09536e4d35b82e99138cb5d069",
+      "amount": {
+        "value": {
+          "unscaledValue": "-1967",
+          "scale": "1"
+        },
+        "currencyCode": "SEK"
+      },
+      "descriptions": {
+        "original": "Lidl",
+        "display": "Lidl"
+      },
+      "dates": {
+        "booked": "2022-11-20"
+      },
+      "types": {
+        "type": "DEFAULT"
+      },
+      "status": "PENDING",
+      "providerMutability": "MUTABILITY_UNDEFINED"
+    }
+  ]
+}

--- a/frontend/lib/components/history_list.dart
+++ b/frontend/lib/components/history_list.dart
@@ -3,6 +3,7 @@ import 'dart:developer';
 import 'package:economicalc_client/helpers/sqlite.dart';
 import 'package:economicalc_client/helpers/utils.dart';
 import 'package:economicalc_client/models/receipt.dart';
+import 'package:economicalc_client/models/transaction.dart';
 import 'package:economicalc_client/screens/transaction_details_screen.dart';
 import 'package:economicalc_client/services/api_calls.dart';
 import 'package:flutter/material.dart';
@@ -16,8 +17,8 @@ class HistoryList extends StatefulWidget {
 }
 
 class HistoryListState extends State<HistoryList> {
-  late Future<List<Receipt>> dataFuture;
-  late List<Receipt> transactions;
+  late Future<List<Transaction>> dataFuture;
+  late List<Transaction> transactions;
   final SQFLite dbConnector = SQFLite.instance;
 
   @override
@@ -28,7 +29,7 @@ class HistoryListState extends State<HistoryList> {
 
   void fetchTransactions() {
     dbConnector.initDatabase();
-    dataFuture = dbConnector.transactions();
+    dataFuture = dbConnector.getAllTransactions();
   }
 
   void sortByDate() {
@@ -75,13 +76,13 @@ class HistoryListState extends State<HistoryList> {
                                     color: Colors.transparent,
                                   )),
                                   title: Text(
-                                    transactions[index].recipient,
+                                    transactions[index].store!,
                                     style: TextStyle(
                                         fontWeight: FontWeight.w600,
                                         fontSize: 18),
                                   ),
                                   subtitle: Text(
-                                    "${transactions[index].total} kr",
+                                    "${transactions[index].totalAmount} kr",
                                     style: TextStyle(
                                         fontWeight: FontWeight.w600,
                                         fontSize: 16),

--- a/frontend/lib/components/history_list.dart
+++ b/frontend/lib/components/history_list.dart
@@ -1,12 +1,15 @@
+import 'dart:convert';
 import 'dart:developer';
 
 import 'package:economicalc_client/helpers/sqlite.dart';
 import 'package:economicalc_client/helpers/utils.dart';
 import 'package:economicalc_client/models/receipt.dart';
 import 'package:economicalc_client/models/transaction.dart';
+import 'package:economicalc_client/models/bank_transaction.dart';
 import 'package:economicalc_client/screens/transaction_details_screen.dart';
 import 'package:economicalc_client/services/api_calls.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_phoenix/flutter_phoenix.dart';
 import 'package:intl/intl.dart';
 import 'package:loading_animation_widget/loading_animation_widget.dart';
@@ -21,15 +24,38 @@ class HistoryListState extends State<HistoryList> {
   late List<Transaction> transactions;
   final SQFLite dbConnector = SQFLite.instance;
 
+  late Future<List<BankTransaction>> bankTransactions;
+  late List<Transaction> transactions_bank;
+
   @override
   void initState() {
     super.initState();
+    load_test_data();
     fetchTransactions();
   }
 
   void fetchTransactions() {
     dbConnector.initDatabase();
     dataFuture = dbConnector.getAllTransactions();
+    bankTransactions = dbConnector.getBankTransactions();
+  }
+
+  void load_test_data() async {
+    final String jsondata =
+        await rootBundle.loadString('assets/test_data.json');
+
+    final data = await json.decode(jsondata);
+
+    final List<BankTransaction> testTransactions = [];
+    BankTransaction trans = BankTransaction.fromJson(data["transactions"][0]);
+    data["transactions"].forEach((transaction) {
+      testTransactions.add(BankTransaction.fromJson(transaction));
+    });
+
+    for (var transaction in testTransactions) {
+      dbConnector.postBankTransaction(transaction);
+    }
+    dbConnector.importMissingBankTransactions();
   }
 
   void sortByDate() {

--- a/frontend/lib/models/bank_transaction.dart
+++ b/frontend/lib/models/bank_transaction.dart
@@ -31,6 +31,23 @@ class BankTransaction {
     providerMutability = json['providerMutability'];
   }
 
+  Map<String, dynamic> toDbFormat() {
+    final Map<String, dynamic> data = Map<String, dynamic>();
+
+    data['id'] = id;
+    data['accountId'] = accountId;
+    data['amountvalueunscaledValue'] = amount.value.unscaledValue;
+    data['amountvaluescale'] = amount.value.scale;
+    data['amountcurrencyCode'] = amount.currencyCode;
+    data['descriptionsoriginal'] = descriptions.original;
+    data['descriptionsdisplay'] = descriptions.display;
+    data['datesbooked'] = dates.booked;
+    data['typestype'] = types.type;
+    data['status'] = status;
+    data['providerMutability'] = providerMutability;
+    return data;
+  }
+
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = Map<String, dynamic>();
     data['id'] = this.id;

--- a/frontend/lib/models/bank_transaction.dart
+++ b/frontend/lib/models/bank_transaction.dart
@@ -1,0 +1,145 @@
+class BankTransaction {
+  late String id;
+  late String accountId;
+  late Amount amount;
+  late Descriptions descriptions;
+  late Dates dates;
+  late Types types;
+  late String status;
+  late String providerMutability;
+
+  BankTransaction(
+      {required this.id,
+      required this.accountId,
+      required this.amount,
+      required this.descriptions,
+      required this.dates,
+      required this.types,
+      required this.status,
+      required this.providerMutability});
+
+  BankTransaction.fromJson(Map<String, dynamic> json) {
+    id = json['id'];
+    accountId = json['accountId'];
+    amount = (json['amount'] != null ? Amount.fromJson(json['amount']) : null)!;
+    descriptions = (json['descriptions'] != null
+        ? Descriptions.fromJson(json['descriptions'])
+        : null)!;
+    dates = (json['dates'] != null ? Dates.fromJson(json['dates']) : null)!;
+    types = (json['types'] != null ? Types.fromJson(json['types']) : null)!;
+    status = json['status'];
+    providerMutability = json['providerMutability'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = Map<String, dynamic>();
+    data['id'] = this.id;
+    data['accountId'] = this.accountId;
+    if (this.amount != null) {
+      data['amount'] = this.amount.toJson();
+    }
+    if (this.descriptions != null) {
+      data['descriptions'] = this.descriptions.toJson();
+    }
+    if (this.dates != null) {
+      data['dates'] = this.dates.toJson();
+    }
+    if (this.types != null) {
+      data['types'] = this.types.toJson();
+    }
+    data['status'] = this.status;
+    data['providerMutability'] = this.providerMutability;
+    return data;
+  }
+}
+
+class Amount {
+  late Value value;
+  late String currencyCode;
+
+  Amount({required this.value, required this.currencyCode});
+
+  Amount.fromJson(Map<String, dynamic> json) {
+    value = (json['value'] != null ? Value.fromJson(json['value']) : null)!;
+    currencyCode = json['currencyCode'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = Map<String, dynamic>();
+    if (value != null) {
+      data['value'] = value.toJson();
+    }
+    data['currencyCode'] = currencyCode;
+    return data;
+  }
+}
+
+class Value {
+  late String unscaledValue;
+  late String scale;
+
+  Value({required this.unscaledValue, required this.scale});
+
+  Value.fromJson(Map<String, dynamic> json) {
+    unscaledValue = json['unscaledValue'];
+    scale = json['scale'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = Map<String, dynamic>();
+    data['unscaledValue'] = unscaledValue;
+    data['scale'] = scale;
+    return data;
+  }
+}
+
+class Descriptions {
+  late String original;
+  late String display;
+
+  Descriptions({required this.original, required this.display});
+
+  Descriptions.fromJson(Map<String, dynamic> json) {
+    original = json['original'];
+    display = json['display'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = new Map<String, dynamic>();
+    data['original'] = original;
+    data['display'] = display;
+    return data;
+  }
+}
+
+class Dates {
+  late String booked;
+
+  Dates({required this.booked});
+
+  Dates.fromJson(Map<String, dynamic> json) {
+    booked = json['booked'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = Map<String, dynamic>();
+    data['booked'] = booked;
+    return data;
+  }
+}
+
+class Types {
+  late String type;
+
+  Types({required this.type});
+
+  Types.fromJson(Map<String, dynamic> json) {
+    type = json['type'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = Map<String, dynamic>();
+    data['type'] = type;
+    return data;
+  }
+}

--- a/frontend/lib/models/category.dart
+++ b/frontend/lib/models/category.dart
@@ -11,22 +11,21 @@ class Category {
     return {
       'description': description,
       'color': color.value.toInt(),
-    }; 
+    };
   }
 
   factory Category.fromJson(Map<String, dynamic> json) {
     return Category(
-      description: json['description'],
-      color: Color(json['color']).withOpacity(1),
-      id: json['id']
-    );
+        description: json['description'],
+        color: Color(json['color']).withOpacity(1),
+        id: json['id']);
   }
 
   static String getCategoryDescription(Category category) {
     return category.description;
   }
 
-  static Category getCategory(String desc, categories) {
-    return categories.firstWhere((item) => item.description == desc);
+  static Category getCategory(String categoryID, categories) {
+    return categories.firstWhere((item) => item.id == categoryID);
   }
 }

--- a/frontend/lib/models/response.dart
+++ b/frontend/lib/models/response.dart
@@ -1,5 +1,3 @@
-import 'dart:ffi';
-
 class Response {
   late String tokenType;
   late int expiresIn;

--- a/frontend/lib/models/transaction.dart
+++ b/frontend/lib/models/transaction.dart
@@ -1,145 +1,48 @@
+import 'package:economicalc_client/models/receipt.dart';
+import 'package:economicalc_client/models/bank_transaction.dart';
+import 'package:intl/intl.dart';
+
 class Transaction {
-  late String id;
-  late String accountId;
-  late Amount amount;
-  late Descriptions descriptions;
-  late Dates dates;
-  late Types types;
-  late String status;
-  late String providerMutability;
+  int? id;
+  DateTime date;
+  double? totalAmount;
+  String? store;
+  int? bankTransactionID;
+  int? receiptID;
+  int? categoryID;
+  String? categoryDesc;
 
   Transaction(
-      {required this.id,
-      required this.accountId,
-      required this.amount,
-      required this.descriptions,
-      required this.dates,
-      required this.types,
-      required this.status,
-      required this.providerMutability});
+      {this.id,
+      required this.date,
+      this.totalAmount,
+      this.store,
+      this.bankTransactionID,
+      this.receiptID,
+      this.categoryID,
+      this.categoryDesc});
 
-  Transaction.fromJson(Map<String, dynamic> json) {
-    id = json['id'];
-    accountId = json['accountId'];
-    amount = (json['amount'] != null ? Amount.fromJson(json['amount']) : null)!;
-    descriptions = (json['descriptions'] != null
-        ? Descriptions.fromJson(json['descriptions'])
-        : null)!;
-    dates = (json['dates'] != null ? Dates.fromJson(json['dates']) : null)!;
-    types = (json['types'] != null ? Types.fromJson(json['types']) : null)!;
-    status = json['status'];
-    providerMutability = json['providerMutability'];
+  Map<String, dynamic> toMap() {
+    return {
+      'date': date.toIso8601String(),
+      'totalAmount': totalAmount,
+      'store': store,
+      'bankTransactionID': bankTransactionID,
+      'receiptID': receiptID,
+      'categoryID': categoryID,
+      'categoryDesc': categoryDesc
+    };
   }
 
-  Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = Map<String, dynamic>();
-    data['id'] = this.id;
-    data['accountId'] = this.accountId;
-    if (this.amount != null) {
-      data['amount'] = this.amount.toJson();
-    }
-    if (this.descriptions != null) {
-      data['descriptions'] = this.descriptions.toJson();
-    }
-    if (this.dates != null) {
-      data['dates'] = this.dates.toJson();
-    }
-    if (this.types != null) {
-      data['types'] = this.types.toJson();
-    }
-    data['status'] = this.status;
-    data['providerMutability'] = this.providerMutability;
-    return data;
-  }
-}
-
-class Amount {
-  late Value value;
-  late String currencyCode;
-
-  Amount({required this.value, required this.currencyCode});
-
-  Amount.fromJson(Map<String, dynamic> json) {
-    value = (json['value'] != null ? Value.fromJson(json['value']) : null)!;
-    currencyCode = json['currencyCode'];
-  }
-
-  Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = Map<String, dynamic>();
-    if (value != null) {
-      data['value'] = value.toJson();
-    }
-    data['currencyCode'] = currencyCode;
-    return data;
-  }
-}
-
-class Value {
-  late String unscaledValue;
-  late String scale;
-
-  Value({required this.unscaledValue, required this.scale});
-
-  Value.fromJson(Map<String, dynamic> json) {
-    unscaledValue = json['unscaledValue'];
-    scale = json['scale'];
-  }
-
-  Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = Map<String, dynamic>();
-    data['unscaledValue'] = unscaledValue;
-    data['scale'] = scale;
-    return data;
-  }
-}
-
-class Descriptions {
-  late String original;
-  late String display;
-
-  Descriptions({required this.original, required this.display});
-
-  Descriptions.fromJson(Map<String, dynamic> json) {
-    original = json['original'];
-    display = json['display'];
-  }
-
-  Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = new Map<String, dynamic>();
-    data['original'] = original;
-    data['display'] = display;
-    return data;
-  }
-}
-
-class Dates {
-  late String booked;
-
-  Dates({required this.booked});
-
-  Dates.fromJson(Map<String, dynamic> json) {
-    booked = json['booked'];
-  }
-
-  Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = Map<String, dynamic>();
-    data['booked'] = booked;
-    return data;
-  }
-}
-
-class Types {
-  late String type;
-
-  Types({required this.type});
-
-  Types.fromJson(Map<String, dynamic> json) {
-    type = json['type'];
-  }
-
-  Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = Map<String, dynamic>();
-    data['type'] = type;
-    return data;
+  factory Transaction.fromJson(Map<String, dynamic> json) {
+    return Transaction(
+      date: DateFormat('yyyy-MM-dd').parse(json['date']),
+      totalAmount: json['totalAmount'],
+      store: json['store'],
+      bankTransactionID: json['bankTransactionID'],
+      receiptID: json['receiptID'],
+      categoryID: json['categoryID'],
+      categoryDesc: json['categoryDesc'],
+    );
   }
 }

--- a/frontend/lib/models/transaction.dart
+++ b/frontend/lib/models/transaction.dart
@@ -7,7 +7,7 @@ class Transaction {
   DateTime date;
   double? totalAmount;
   String? store;
-  int? bankTransactionID;
+  String? bankTransactionID;
   int? receiptID;
   int? categoryID;
   String? categoryDesc;

--- a/frontend/lib/screens/settings_categories_screen.dart
+++ b/frontend/lib/screens/settings_categories_screen.dart
@@ -22,7 +22,7 @@ class _CategoriesScreenState extends State<CategoriesScreen> {
   @override
   void initState() {
     super.initState();
-    categoryFuture = dbConnector.categories();
+    categoryFuture = dbConnector.getAllcategories();
   }
 
   void getCategories() async {

--- a/frontend/lib/screens/transaction_details_screen.dart
+++ b/frontend/lib/screens/transaction_details_screen.dart
@@ -2,13 +2,14 @@ import 'package:economicalc_client/helpers/utils.dart';
 import 'package:economicalc_client/models/category.dart';
 import 'package:economicalc_client/models/receipt.dart';
 import 'package:economicalc_client/helpers/sqlite.dart';
+import 'package:economicalc_client/models/transaction.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 var dropDownItems = Utils.categories;
 
 class TransactionDetailsScreen extends StatefulWidget {
-  final Receipt transaction;
+  final Transaction transaction;
 
   TransactionDetailsScreen(Key? key, this.transaction) : super(key: key);
 
@@ -26,6 +27,8 @@ class TransactionDetailsScreenState extends State<TransactionDetailsScreen> {
   late String? dropdownValue;
   late Future<List<Category>> categoriesFutureBuilder;
   late List<Category> categories;
+  late Receipt receipt;
+  late Future<Receipt> receiptFutureBuilder;
 
   @override
   void initState() {
@@ -33,6 +36,8 @@ class TransactionDetailsScreenState extends State<TransactionDetailsScreen> {
     dbConnector.initDatabase();
     dropdownValue = widget.transaction.categoryDesc;
     categoriesFutureBuilder = getCategories(dbConnector);
+    receiptFutureBuilder =
+        getReceipt(dbConnector, widget.transaction.receiptID!);
   }
 
   @override
@@ -77,12 +82,15 @@ class TransactionDetailsScreenState extends State<TransactionDetailsScreen> {
                     isDense: true,
                     isExpanded: true,
                     value: dropdownValue,
-                    onChanged: (value) {
+                    onChanged: (value) async {
                       setState(() {
                         dropdownValue = value;
-                        widget.transaction.categoryDesc = dropdownValue;
                       });
-                      dbConnector.updatetransaction(widget.transaction);
+                      widget.transaction.categoryDesc = dropdownValue;
+                      widget.transaction.categoryID =
+                          await SQFLite.getCategoryIDfromDescription(
+                              dropdownValue!);
+                      dbConnector.updateTransaction(widget.transaction!);
                     },
                     items: categories
                         .map<DropdownMenuItem<String>>((Category category) {
@@ -93,8 +101,7 @@ class TransactionDetailsScreenState extends State<TransactionDetailsScreen> {
                             style: TextStyle(
                                 fontSize: fontSize,
                                 fontWeight: FontWeight.w600,
-                                color: category.color))
-                                ,
+                                color: category.color)),
                       );
                     }).toList()));
           } else {
@@ -123,7 +130,7 @@ class TransactionDetailsScreenState extends State<TransactionDetailsScreen> {
                     Padding(
                         padding: EdgeInsets.only(left: 5),
                         child: Text(
-                          widget.transaction.recipient,
+                          widget.transaction.store!,
                           style: TextStyle(
                               fontSize: fontSize, fontWeight: FontWeight.w600),
                         )),
@@ -149,7 +156,7 @@ class TransactionDetailsScreenState extends State<TransactionDetailsScreen> {
                 padding: EdgeInsets.all(10),
                 child: Column(children: [
                   Icon(Icons.payment),
-                  Text("${widget.transaction.total} kr",
+                  Text("${widget.transaction.totalAmount} kr",
                       style: TextStyle(
                           fontSize: fontSize, fontWeight: FontWeight.w600))
                 ])),
@@ -164,12 +171,23 @@ class TransactionDetailsScreenState extends State<TransactionDetailsScreen> {
   }
 
   Widget buildDataTable() {
-    return DataTable(
-        columnSpacing: 30,
-        sortAscending: isAscending,
-        sortColumnIndex: sortColumnIndex,
-        columns: getColumns(columns),
-        rows: getRows(widget.transaction.items as List<ReceiptItem>));
+    return FutureBuilder(
+        future: receiptFutureBuilder,
+        builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            return Text("${snapshot.error}");
+          } else if (snapshot.hasData) {
+            receipt = snapshot.data!;
+            return DataTable(
+                columnSpacing: 30,
+                sortAscending: isAscending,
+                sortColumnIndex: sortColumnIndex,
+                columns: getColumns(columns),
+                rows: getRows(receipt.items));
+          } else {
+            return Text("Unexpected error");
+          }
+        });
   }
 
   List<DataColumn> getColumns(List<String> columns) => columns
@@ -190,10 +208,10 @@ class TransactionDetailsScreenState extends State<TransactionDetailsScreen> {
 
   void onSort(int columnIndex, bool ascending) {
     if (columnIndex == 0) {
-      widget.transaction.items.sort((row1, row2) =>
+      receipt.items.sort((row1, row2) =>
           Utils.compareString(ascending, row1.itemName, row2.itemName));
     } else if (columnIndex == 1) {
-      widget.transaction.items.sort((row1, row2) =>
+      receipt.items.sort((row1, row2) =>
           Utils.compareNumber(ascending, row1.amount, row2.amount));
     }
 
@@ -202,7 +220,12 @@ class TransactionDetailsScreenState extends State<TransactionDetailsScreen> {
       isAscending = ascending;
     });
   }
+
   Future<List<Category>> getCategories(SQFLite dbConnector) async {
-    return await dbConnector.categories();
+    return await dbConnector.getAllcategories();
+  }
+
+  Future<Receipt> getReceipt(SQFLite dbConnector, int id) async {
+    return await dbConnector.getReceiptfromID(id);
   }
 }

--- a/frontend/lib/screens/transaction_details_screen.dart
+++ b/frontend/lib/screens/transaction_details_screen.dart
@@ -28,7 +28,7 @@ class TransactionDetailsScreenState extends State<TransactionDetailsScreen> {
   late Future<List<Category>> categoriesFutureBuilder;
   late List<Category> categories;
   late Receipt receipt;
-  late Future<Receipt> receiptFutureBuilder;
+  late Future<Receipt>? receiptFutureBuilder;
 
   @override
   void initState() {
@@ -36,8 +36,12 @@ class TransactionDetailsScreenState extends State<TransactionDetailsScreen> {
     dbConnector.initDatabase();
     dropdownValue = widget.transaction.categoryDesc;
     categoriesFutureBuilder = getCategories(dbConnector);
-    receiptFutureBuilder =
-        getReceipt(dbConnector, widget.transaction.receiptID!);
+    if (widget.transaction.receiptID != null) {
+      receiptFutureBuilder =
+          getReceipt(dbConnector, widget.transaction.receiptID!);
+    } else {
+      receiptFutureBuilder = null;
+    }
   }
 
   @override
@@ -185,7 +189,7 @@ class TransactionDetailsScreenState extends State<TransactionDetailsScreen> {
                 columns: getColumns(columns),
                 rows: getRows(receipt.items));
           } else {
-            return Text("Unexpected error");
+            return Center(heightFactor: 20, child: Text("No receipt data"));
           }
         });
   }

--- a/frontend/lib/services/api_calls.dart
+++ b/frontend/lib/services/api_calls.dart
@@ -1,5 +1,5 @@
 import 'package:economicalc_client/models/response.dart';
-import 'package:economicalc_client/models/transaction.dart';
+import 'package:economicalc_client/models/bank_transaction.dart';
 import 'package:economicalc_client/models/receipt.dart';
 import 'package:flutter/material.dart';
 
@@ -43,7 +43,7 @@ Future<List<ReceiptItem>> fetchMockedReceiptItems() async {
       .items;
 }
 
-Future<List<Transaction>> fetchTransactions(String access_token) async {
+Future<List<BankTransaction>> fetchTransactions(String access_token) async {
   //print("INSIDE TRANSACTIOn");
   String path = '/tink_transaction_history/';
   path += access_token;
@@ -52,9 +52,9 @@ Future<List<Transaction>> fetchTransactions(String access_token) async {
     List<dynamic> transactions =
         convert.jsonDecode(response.body)["transactions"];
     //print(transactions);
-    List<Transaction> resTrans = [];
+    List<BankTransaction> resTrans = [];
     transactions.forEach((transaction) {
-      resTrans.add(Transaction.fromJson(transaction));
+      resTrans.add(BankTransaction.fromJson(transaction));
     });
     //print("RESTRANSACT");
     //print(resTrans);

--- a/frontend/lib/services/open_link.dart
+++ b/frontend/lib/services/open_link.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:core';
 
 import 'package:economicalc_client/models/response.dart';
-import 'package:economicalc_client/models/transaction.dart';
+import 'package:economicalc_client/models/bank_transaction.dart';
 import 'package:economicalc_client/services/api_calls.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/container.dart';
@@ -36,7 +36,7 @@ class OpenLinkState extends State<OpenLink> {
       "https://link.tink.com/1.0/transactions/connect-accounts/?client_id=1a539460199a4e8bb374893752db14e6&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&market=SE&locale=sv_SE&test=true";
 
   late final Response response;
-  late final Future<List<Transaction>> transactions;
+  late final Future<List<BankTransaction>> transactions;
 
   @override
   void initState() {


### PR DESCRIPTION
Everything works exactly the same as in master, but the main data structure is now transactions, which can hold the id for a bank transaction (previously called transaction) and a receipt.

The idea is to always have a stable source of data for the frontend to fetch from. The data for each transaction can then be updated without disturbing the flow, and fetch its data accordingly depending on if a transaction includes a bank transaction or a receipt or both.