### PR TITLE
throw exception and display message for unsuccessful ocr api requests

### DIFF
--- a/frontend/lib/helpers/quota_exception.dart
+++ b/frontend/lib/helpers/quota_exception.dart
@@ -1,0 +1,18 @@
+class QuotaException implements Exception {
+  String cause;
+  QuotaException(this.cause);
+}
+
+void main() {
+  try {
+    throwException();
+  } on QuotaException {
+    print(
+        'Hourly quota exceeded. Try again in a few hours or contact us to increase the quota: ocr@asprise.com');
+  }
+}
+
+throwException() {
+  throw QuotaException(
+      'Hourly quota exceeded. Try again in a few hours or contact us to increase the quota: ocr@asprise.com');
+}

--- a/frontend/lib/helpers/utils.dart
+++ b/frontend/lib/helpers/utils.dart
@@ -11,6 +11,7 @@ class Utils {
   static Color backgroundColor = Color(0xFFB8D8D8);
   static Color tileColor = Color(0xffD4E6F3);
   static Color drawerColor = Color(0xff69A3A7);
+  static Color snackBarError = Color(0xFFC72C41);
 
   static List<Category> categories = [
     Category(description: "Groceries", color: Colors.blue),

--- a/frontend/lib/screens/home_screen.dart
+++ b/frontend/lib/screens/home_screen.dart
@@ -68,7 +68,9 @@ class _HomeScreen extends State<HomeScreen> {
         .push(MaterialPageRoute(
             builder: (context) => ResultsScreen(image: image)))
         .then((value) {
-      Phoenix.rebirth(_context);
+      if (value != false) {
+        Phoenix.rebirth(_context);
+      }
     });
   }
 
@@ -434,7 +436,7 @@ class _HomeScreen extends State<HomeScreen> {
       iconSection(),
       Expanded(
           child: HistoryList(historyListStateKey, startDate['selected'],
-              endDate['selected'], category['selected']))
+              endDate['selected'], category['selected'])),
     ];
     if (showSearchBar) {
       children = [


### PR DESCRIPTION
User will be redirected to the home page and an error message will be displayed if ocr api does not succeed. Displays two different messages, one for daily quota limit and one for "bad" image requests.