### PR TITLE
ask user to merge receipt to existing bank transaction

### DIFF
--- a/frontend/lib/helpers/sqlite.dart
+++ b/frontend/lib/helpers/sqlite.dart
@@ -147,7 +147,7 @@ class SQFLite {
           transaction.store?.toLowerCase().trim()) {
         tran.categoryID = transaction.categoryID;
         tran.categoryDesc = transaction.categoryDesc;
-        updateTransaction(tran);
+        await updateTransaction(tran);
       }
     }
   }

--- a/frontend/lib/screens/results_screen.dart
+++ b/frontend/lib/screens/results_screen.dart
@@ -170,29 +170,17 @@ class ResultsScreenState extends State<ResultsScreen> {
               Transaction? alreadyExists =
                   await dbConnector.checkForExistingTransaction(transaction);
               if (alreadyExists != null) {
-                alreadyExists.receiptID = receiptID;
-                alreadyExists.date = transaction.date;
-                alreadyExists.categoryDesc = transaction.categoryDesc;
-                alreadyExists.categoryID = transaction.categoryID;
-                await dbConnector.updateTransaction(alreadyExists);
-                final snackBar = SnackBar(
-                  backgroundColor: Utils.mediumDarkColor,
-                  content: Text(
-                    "Receipt was added to existing identical bank transaction",
-                    style: TextStyle(color: Utils.lightColor),
-                  ),
-                );
-                ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                await showMergeTransactionDialog(
+                    context, alreadyExists, transaction);
               } else {
                 await dbConnector.insertTransaction(transaction);
               }
               int? n =
                   await dbConnector.numOfCategoriesWithSameName(transaction);
               if (n > 0) {
-                showAlertDialog(context, n, transaction);
-              } else {
-                showConfirmationButton(context);
+                await showAlertDialog(context, n, transaction);
               }
+              showConfirmationButton(context);
             }
           },
           child: Row(
@@ -255,7 +243,10 @@ class ResultsScreenState extends State<ResultsScreen> {
 
   showConfirmationButton(BuildContext context) {
     Widget confirmationButton = TextButton(
-      child: Text("Ok"),
+      style: ButtonStyle(
+          foregroundColor:
+              MaterialStateProperty.all<Color>(Utils.mediumDarkColor)),
+      child: Center(child: Text("Ok")),
       onPressed: () {
         Navigator.of(context).popUntil((route) => route.isFirst);
       },
@@ -276,21 +267,25 @@ class ResultsScreenState extends State<ResultsScreen> {
     ).then((value) => Navigator.of(context).popUntil((route) => route.isFirst));
   }
 
-  showAlertDialog(BuildContext context, int n, transaction) {
+  showAlertDialog(BuildContext context, int n, transaction) async {
     // set up the buttons
     Widget cancelButton = TextButton(
+      style: ButtonStyle(
+          foregroundColor:
+              MaterialStateProperty.all<Color>(Utils.mediumDarkColor)),
       child: Text("No"),
       onPressed: () {
         Navigator.of(context, rootNavigator: true).pop('dialog');
-        showConfirmationButton(context);
       },
     );
     Widget continueButton = TextButton(
+      style: ButtonStyle(
+          foregroundColor:
+              MaterialStateProperty.all<Color>(Utils.mediumDarkColor)),
       child: Text("Yes"),
-      onPressed: () {
-        dbConnector.assignCategories(transaction);
+      onPressed: () async {
+        await dbConnector.assignCategories(transaction);
         Navigator.of(context, rootNavigator: true).pop('dialog');
-        showConfirmationButton(context);
       },
     );
 
@@ -311,7 +306,63 @@ class ResultsScreenState extends State<ResultsScreen> {
     );
 
     // show the dialog
-    showDialog(
+    await showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return alert;
+      },
+    );
+  }
+
+  showMergeTransactionDialog(BuildContext context, Transaction alreadyExists,
+      Transaction transaction) async {
+    // set up the buttons
+    Widget cancelButton = TextButton(
+      style: ButtonStyle(
+          foregroundColor:
+              MaterialStateProperty.all<Color>(Utils.mediumDarkColor)),
+      child: Text("No"),
+      onPressed: () async {
+        await dbConnector.insertTransaction(transaction);
+        Navigator.of(context, rootNavigator: true).pop('dialog');
+      },
+    );
+    Widget continueButton = TextButton(
+      style: ButtonStyle(
+          foregroundColor:
+              MaterialStateProperty.all<Color>(Utils.mediumDarkColor)),
+      child: Text("Yes"),
+      onPressed: () async {
+        alreadyExists.receiptID = transaction.receiptID;
+        alreadyExists.date = transaction.date;
+        alreadyExists.categoryDesc = transaction.categoryDesc;
+        alreadyExists.categoryID = transaction.categoryID;
+        await dbConnector.updateTransaction(alreadyExists);
+        final snackBar = SnackBar(
+          backgroundColor: Utils.mediumDarkColor,
+          content: Text(
+            "Receipt was added to existing identical bank transaction",
+            style: TextStyle(color: Utils.lightColor),
+          ),
+        );
+        ScaffoldMessenger.of(context).showSnackBar(snackBar);
+        Navigator.of(context, rootNavigator: true).pop('dialog');
+        // showConfirmationButton(context);
+      },
+    );
+
+    // set up the AlertDialog
+    AlertDialog alert = AlertDialog(
+      title: Text("An existing bank transaction for this receipt was found."),
+      content: Text(
+          "Would you like to attach this receipt to that bank transaction?"),
+      actions: [
+        cancelButton,
+        continueButton,
+      ],
+    );
+
+    await showDialog(
       context: context,
       builder: (BuildContext context) {
         return alert;

--- a/frontend/lib/screens/transaction_details_screen.dart
+++ b/frontend/lib/screens/transaction_details_screen.dart
@@ -462,12 +462,18 @@ class TransactionDetailsScreenState extends State<TransactionDetailsScreen> {
   deleteAlertDialog(BuildContext context) {
     // set up the buttons
     Widget cancelButton = TextButton(
+      style: ButtonStyle(
+          foregroundColor:
+              MaterialStateProperty.all<Color>(Utils.mediumDarkColor)),
       child: Text("No"),
       onPressed: () {
         Navigator.of(context).pop();
       },
     );
     Widget continueButton = TextButton(
+      style: ButtonStyle(
+          foregroundColor:
+              MaterialStateProperty.all<Color>(Utils.mediumDarkColor)),
       child: Text("Yes"),
       onPressed: () async {
         await dbConnector.deleteReceipt(widget.transaction.receiptID!);
@@ -486,7 +492,8 @@ class TransactionDetailsScreenState extends State<TransactionDetailsScreen> {
     AlertDialog alert = AlertDialog(
       title: Text("Delete receipt"),
       content: Text(
-          "Are you sure you want to delete this receipt? This action cannot be undone."),
+          """Are you sure you want to delete the receipt? This action cannot be undone.
+          \nCorresponding bank transaction will not be removed if it exists."""),
       actions: [
         cancelButton,
         continueButton,


### PR DESCRIPTION
The user will now be asked to attach the receipt to an existing identical bank transaction. If answered yes, the receipt id will be added to the existing transaction. If answered no, the receipt will be added as a separate transaction.